### PR TITLE
Tulu Experiments with LLaMA 4-bit Models

### DIFF
--- a/tulu/src/data.py
+++ b/tulu/src/data.py
@@ -1,0 +1,14 @@
+import json
+
+# This script unites several files of sft-data (batches) in a single sft-dataset
+all_data = []
+batch_number = 7
+
+for i in range(1, batch_number):
+    with open(f"../data/sft_batch_{i}.json", "r") as f:
+        batch = json.load(f)
+        all_data.extend(batch)
+
+# Save full dataset
+with open("../data/sft_dataset.json", "w") as f:
+    json.dump(all_data, f, indent=2)

--- a/tulu/src/requirements.txt
+++ b/tulu/src/requirements.txt
@@ -1,0 +1,6 @@
+transformers
+datasets
+unsloth
+wandb
+pandas
+

--- a/tulu/src/tuning-config.yaml
+++ b/tulu/src/tuning-config.yaml
@@ -1,0 +1,53 @@
+tuning:
+  # type: sft
+  type: dpo
+
+base_model:
+  # name: unsloth/Llama-3.2-1B-bnb-4bit
+  # name: unsloth/Llama-3.2-3B-bnb-4bit
+  # name: unsloth/Meta-Llama-3.1-8B-Instruct
+  name: unsloth/Llama-3.2-1B-Instruct-bnb-4bit
+
+sft_dataset:
+  # name: allenai/tulu-3-sft-personas-math-grade
+  # name: allenai/tulu-3-sft-personas-math
+  # name: allenai/tulu-3-sft-personas-instruction-following
+  # name: allenai/tulu-3-sft-personas-algebra
+  # name: allenai/tulu-3-sft-personas-code
+  # name: allenai/tulu-3-sft-mixture
+  name: sft_dataset_509
+
+sft_model:
+  # name: alextsiak/llama-3.2-1B-bnb-4bit-mix-500st
+  # name: rodionzorin/llama-3.2-3B-bnb-4bit_finetuned_tulu-3-sft-mixture
+  # mzarev/Llama-3.1-8B-bnb-4bit-mix-500st
+  # name: unsloth/Meta-Llama-3.1-8B-Instruct
+  name: not_used
+
+preference_dataset:
+  #cname: allenai/llama-3.1-tulu-3-8b-preference-mixture
+  # name: allenai/llama-3.1-tulu-3-70b-preference-mixture
+  # name: allenai/llama-3.1-tulu-3-405b-preference-mixture
+  # name: allenai/tulu-3-IF-augmented-on-policy-8b
+  name: not_used
+  
+
+max_seq_length:
+  length: 2048
+
+low_rank_matrice:
+  size: 16 # also recommended 32, 64, 128
+
+influence:
+  rate: 16 # also recommended 32, 64, 128
+
+dropout:
+  rate: 0.05
+
+training:
+  learning_rate: 2e-4
+  batch_size: 4
+  grad_acc_steps: 4
+  max_training_steps: 700
+  warmup_steps: 20
+  beta: 0.1

--- a/tulu/src/tuning.py
+++ b/tulu/src/tuning.py
@@ -1,0 +1,273 @@
+import yaml
+import argparse
+from unsloth import FastLanguageModel
+from transformers import BitsAndBytesConfig
+from trl import SFTTrainer, SFTConfig, DPOTrainer, DPOConfig
+from trl.trainer.utils import SIMPLE_CHAT_TEMPLATE
+import torch
+from datasets import load_dataset
+import json
+from utils import formatting_func, run_wandb
+import wandb
+import os
+
+os.environ["TORCHINDUCTOR_CACHE_DIR"] = "/home/users/rzorin/.cache/torchinductor"
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    '--config',
+    type=str,
+    required=True,
+    help="Please set your training parameters in config-sft.yaml")
+args = parser.parse_args()
+
+with open(args.config) as f:
+    config = yaml.safe_load(f)
+
+#type tuning
+tuning = config['tuning']['type']
+#model and dataset
+base_model_name = config['base_model']['name']
+sft_dataset_name = config['sft_dataset']['name']
+sft_model_name = config['sft_model']['name']
+preference_dataset_name = config['preference_dataset']['name']
+#context length
+max_seq_length = int(config['max_seq_length']['length'])
+#lora specific parameters
+matrice_size = int(config['low_rank_matrice']['size'])
+influence = int(config['influence']['rate'])
+dropout = float(config['dropout']['rate'])
+#hyperparameters
+lr = float(config['training']['learning_rate'])
+batch_size = int(config['training']['batch_size'])
+grad_acc_steps = int(config['training']['grad_acc_steps'])
+max_training_steps = int(config['training']['max_training_steps'])
+warmup_steps = int(config["training"]["warmup_steps"])
+beta = float(config['training']['beta'])
+
+print("*****Config*****")
+if tuning == 'sft':
+    print(f"tuning type: {tuning}\n",
+          f"base_model: {base_model_name}\n",
+          f"sft_dataset: {sft_dataset_name}\n"
+          )
+else: #if tuning == 'dpo'
+    print(f"tuning type: {tuning}\n",
+          f"reference model: {base_model_name}\n",
+          f"sft_model: {sft_model_name}\n",
+          f"preference dataset: {preference_dataset_name}\n",
+          )
+print(f"max_seq_lenght: {max_seq_length}\n",
+      f"matrice_size: {matrice_size}\n",
+      f"influence: {influence}\n",
+      f"dropout: {dropout}\n",
+      f"learning_rate: {lr}\n",
+      f"batch size: {batch_size}\n",
+      f"gradient accumulation steps: {grad_acc_steps}\n",
+      f"max_training_steps: {max_training_steps}\n",
+      f"warmup_steps: {warmup_steps}\n")
+if tuning == 'dpo':
+    print(f"beta: {beta}")
+print("*****End of config*****")
+
+if tuning == 'sft':
+
+    save_dir = f"{base_model_name.split('/')[-1]}_finetuned_{sft_dataset_name.split('/')[-1]}"
+
+    model, tokenizer = FastLanguageModel.from_pretrained(
+        model_name=base_model_name, max_seq_length=max_seq_length, dtype=None, load_in_4bit=True
+        )
+
+    model = FastLanguageModel.get_peft_model(
+        model,
+        r=matrice_size, #the size of the low-rank matrices
+        target_modules=[
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ],
+        lora_alpha=influence, # adjusts how strongly the LoRA modifications affect the model
+        lora_dropout=dropout,  # Supports any, but = 0 is optimized. 
+        bias="none",  # Supports any, but = "none" is optimized
+        use_gradient_checkpointing="unsloth",  # True or "unsloth" for very long context
+        # max_seq_length=max_seq_length,
+        use_rslora=False,  # We support rank stabilized LoRA
+        loftq_config=None,  # And LoftQ
+        )
+
+    # model.config.quantization_config = BitsAndBytesConfig(
+    #     load_in_4bit=True,
+    #     bnb_4bit_use_double_quant=False,
+    #     bnb_4bit_quant_type="nf4",
+    #     bnb_4bit_compute_dtype=torch.float16,
+    #     )
+
+    #train_dataset = load_dataset(sft_dataset_name, split="train")
+    train_dataset = load_dataset("json", data_files=sft_dataset_name)["train"]
+
+    EOS_TOKEN = tokenizer.eos_token # Must add EOS_TOKEN
+    def formatting_func(examples):
+        messages = examples["messages"]
+        texts = [
+            "".join([m["content"].strip() + "\n" for m in convo]).strip() + EOS_TOKEN for convo in messages
+        ]
+        return {"text": texts}
+
+    train_dataset = train_dataset.map(formatting_func, batched=True)
+
+    # Shuffle the dataset before training
+    train_dataset = train_dataset.shuffle(seed=42)
+
+    run_wandb(base_model_name, sft_dataset_name, max_training_steps, lr, batch_size, grad_acc_steps, save_dir)
+
+    trainer = SFTTrainer(
+        model=model,
+        train_dataset=train_dataset,
+        tokenizer=tokenizer,
+        args=SFTConfig(
+            dataset_text_field="text",
+            max_seq_length=max_seq_length,
+            learning_rate=lr,
+            per_device_train_batch_size=batch_size,
+            gradient_accumulation_steps=grad_acc_steps,
+            warmup_steps=warmup_steps,
+            max_steps=max_training_steps,
+            report_to="wandb",
+            run_name=f"{base_model_name}_{sft_dataset_name}",
+            output_dir=os.path.join(save_dir, "outputs"),
+            optim="adamw_8bit",
+        ),
+        )
+
+else: #if tuning == dpo
+
+    save_dir = f"{sft_model_name.split('/')[-1]}_finetuned_{preference_dataset_name.split('/')[-1]}"
+
+    #this is the original ref model
+    ref_model, _ = FastLanguageModel.from_pretrained(
+        model_name=base_model_name,
+        #max_seq_length=2048,
+        dtype=None,
+        load_in_4bit=True,
+    )
+
+    
+    # this is our LoRA-adapted SFT model
+    model, tokenizer = FastLanguageModel.from_pretrained(
+	model_name=sft_model_name,
+	#max_seq_length=2048,
+	dtype=None,
+	load_in_4bit=True,
+    )
+
+    model = FastLanguageModel.get_peft_model(
+	model,
+        #r=matrice_size, #the size of the low-rank matrices
+        #target_modules=[
+        #    "q_proj",
+        #    "k_proj",
+        #    "v_proj",
+        #    "o_proj",
+        #    "gate_proj",
+        #    "up_proj",
+        #    "down_proj",
+        #],
+        #lora_alpha=influence, # adjusts how strongly the LoRA modifications affect the model
+        #lora_dropout=dropout,  # Supports any, but = 0 is optimized. 
+        #bias="none",  # Supports any, but = "none" is optimized
+        #use_gradient_checkpointing="unsloth",  # True or "unsloth" for very long context
+        #max_seq_length=max_seq_length,
+        #use_rslora=False,  # We support rank stabilized LoRA
+        #loftq_config=None,  # And LoftQ
+        )
+
+#    if tokenizer.chat_template is None:
+    	#tokenizer.chat_template = SIMPLE_CHAT_TEMPLATE
+
+    #don't want to train the reference model
+    for param in ref_model.parameters():
+        param.requires_grad = False
+    
+    #model.config.quantization_config = BitsAndBytesConfig(
+    #load_in_4bit=True,
+    #bnb_4bit_use_double_quant=False,
+    #bnb_4bit_quant_type="nf4",
+    #bnb_4bit_compute_dtype=torch.float16,
+    #)   
+    
+    #train_dataset = load_dataset(preference_dataset_name, split="train")
+    train_dataset = load_dataset("json", data_files=preference_dataset_name)["train"]
+
+    # Shuffle the dataset before training
+    train_dataset = train_dataset.shuffle(seed=42)
+
+    run_wandb(sft_model_name, preference_dataset_name, max_training_steps, lr, batch_size, grad_acc_steps, save_dir)
+
+    trainer = DPOTrainer(
+        model=model,
+        ref_model=ref_model,
+        args=DPOConfig(
+            beta=beta,
+            max_length=max_seq_length,
+            learning_rate=lr,
+            per_device_train_batch_size=batch_size,
+            gradient_accumulation_steps=grad_acc_steps,
+            warmup_steps=warmup_steps,
+            max_steps=max_training_steps,
+            report_to="wandb",
+            run_name=f"{sft_model_name}_{preference_dataset_name}",
+            output_dir=os.path.join(save_dir, "outputs"),
+            optim="adamw_8bit",
+        ),
+        train_dataset=train_dataset,
+        processing_class=tokenizer,
+    )
+
+trainer.train()
+
+wandb.finish()
+
+
+model.save_pretrained(save_dir)
+tokenizer.save_pretrained(save_dir)
+
+if tuning == 'sft':
+    filtered_config = {
+        'tuning': config['tuning']['type'],
+        'base_model': config['base_model']['name'],
+        'sft_dataset': config['sft_dataset']['name'],
+        'max_seq_length': config['max_seq_length']['length'],
+        'matrice_size': config['low_rank_matrice']['size'],
+        'influence': config['influence']['rate'],
+        'dropout': config['dropout']['rate'],
+        'lr': config['training']['learning_rate'],
+        'batch_size': config['training']['batch_size'],
+        'grad_acc_steps': config['training']['grad_acc_steps'],
+        'max_training_steps': config['training']['max_training_steps'],
+        'warmup_steps': config["training"]["warmup_steps"]
+        }
+    
+else: #if tuning == 'dpo'
+    filtered_config = {
+        'tuning': config['tuning']['type'],
+        'reference_model': config['base_model']['name'],
+        'sft_model': config['sft_model']['name'],
+        'preference_dataset': config['preference_dataset']['name'],
+        'max_seq_length': config['max_seq_length']['length'],
+        'matrice_size': config['low_rank_matrice']['size'],
+        'influence': config['influence']['rate'],
+        'dropout': config['dropout']['rate'],
+        'lr': config['training']['learning_rate'],
+        'batch_size': config['training']['batch_size'],
+        'grad_acc_steps': config['training']['grad_acc_steps'],
+        'max_training_steps': config['training']['max_training_steps'],
+        'warmup_steps': config["training"]["warmup_steps"],
+        'beta': config['training']['beta']
+        }
+save_path = os.path.join(save_dir, "used_config.yaml")
+with open(save_path, 'w') as f:
+    yaml.dump(filtered_config, f)

--- a/tulu/src/utils.py
+++ b/tulu/src/utils.py
@@ -1,0 +1,26 @@
+import os
+
+def formatting_func(examples):
+    messages = examples["messages"]
+    texts = [
+        "".join([m["content"].strip() + "\n" for m in convo]).strip()
+        for convo in messages
+    ]
+    return {"text": texts}
+
+def run_wandb(model_name, dataset_name, max_steps, lr, batch_size, grad_acc_steps, save_dir):
+    os.environ["WANDB_DIR"] = save_dir
+    import wandb
+    wandb.login(key=os.getenv("WANDB_API_KEY"))
+    wandb.init(
+    project="pm-pt",
+    name=f"{model_name}_{dataset_name}",
+    config={
+        "model": model_name,
+        "dataset": dataset_name,
+        "max_steps": max_steps,
+        "learning_rate": lr,
+        "batch_size": batch_size,
+        "gradient_accumulation_steps": grad_acc_steps,
+    },
+    )

--- a/tulu/tulu-results/README.md
+++ b/tulu/tulu-results/README.md
@@ -1,0 +1,22 @@
+## Experiment description 
+
+The goal of the experiments below is to explore how different types of tuning affect the ability of large language models to perform interactive tasks within the Clembench benchmark. We focus on whether improving a model's general abilities — including instruction-following, conversational capabilities, and broader preference tuning — can lead to better performance in interactive, game-like environments, even without exposing the model to game-specific data.
+
+To test this, we use the LLaMA 3.1 8B Instruct model as the base and apply several tuning strategies, including instruction-following datasets, real-world conversational data (WildChat), and mixture preference datasets. Across most experiments, we rely on DPO (Direct Preference Optimization) as the main tuning approach, with some additional tests using supervised fine-tuning (SFT).
+
+We use Tulu 3 datasets to run our experiments: https://huggingface.co/collections/allenai/tulu-3-datasets-673b8df14442393f7213f372
+
+### Potsdam Blitz Team
+
+Arefeva, Tsiakalou, Zarev, Zorin
+
+### Our Best Model:
+
+Model: LLaMA 3.1 8B Instruct 4-bit tuned with unsloth and DPO
+Dataset: allenai/tulu-3-pref-personas-instruction-following
+Batch size: 4×4, steps: 700
+Results: clemscore 14.39, Avg % Played 34.79, Avg Quality Score 41.35
+
+### The Baseline to compare
+
+The Baseline (Llama3-8b-it-4bit): clemscore 19.58, Avg % Played 49.43, Avg Quality Score 39.62

--- a/tulu/tulu-results/llama3-8b-it-4bit-dpo-lora-preference-data-if.val.json
+++ b/tulu/tulu-results/llama3-8b-it-4bit-dpo-lora-preference-data-if.val.json
@@ -1,0 +1,1 @@
+{"clemscore": 12.63, "statscore": 47.92}

--- a/tulu/tulu-results/llama3-8b-it-4bit.val.json
+++ b/tulu/tulu-results/llama3-8b-it-4bit.val.json
@@ -1,0 +1,1 @@
+{"clemscore": 27.35, "statscore": 49.16}

--- a/tulu/tulu-results/results_Llama_3.1_8b_it_4bit (baseline_no_tuning).html
+++ b/tulu/tulu-results/results_Llama_3.1_8b_it_4bit (baseline_no_tuning).html
@@ -1,0 +1,120 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-t0.0</th>
+      <td>19.58</td>
+      <td>49.43</td>
+      <td>39.62</td>
+      <td>43.08</td>
+      <td>26.79</td>
+      <td>44.69</td>
+      <td>88.33</td>
+      <td>12.58</td>
+      <td>21.9</td>
+      <td>76.27</td>
+      <td>51.98</td>
+      <td>21.12</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>60.0</td>
+      <td>57.43</td>
+      <td>11.29</td>
+      <td>26.67</td>
+      <td>61.27</td>
+      <td>11.77</td>
+      <td>100.0</td>
+      <td>13.33</td>
+      <td>34.57</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>100.0</td>
+      <td>23.32</td>
+      <td>30.37</td>
+      <td>100.0</td>
+      <td>40.0</td>
+      <td>49.26</td>
+      <td>100.0</td>
+      <td>29.17</td>
+      <td>42.48</td>
+      <td>36.0</td>
+      <td>54.89</td>
+      <td>9.61</td>
+      <td>20.0</td>
+      <td>50.2</td>
+      <td>12.05</td>
+      <td>56.67</td>
+      <td>94.12</td>
+      <td>24.25</td>
+      <td>33.33</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF-augmented.html
+++ b/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF-augmented.html
@@ -1,0 +1,120 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-augmented-lora-t0.0</th>
+      <td>3.31</td>
+      <td>9.92</td>
+      <td>33.33</td>
+      <td>3.08</td>
+      <td>50.0</td>
+      <td>57.74</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>4.0</td>
+      <td>58.57</td>
+      <td>2.02</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>56.67</td>
+      <td>17.65</td>
+      <td>39.3</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>38.3</td>
+      <td>35.42</td>
+      <td>23.54</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>66.67</td>
+      <td>5.0</td>
+      <td>22.07</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_pref_personas.html
+++ b/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_pref_personas.html
@@ -1,0 +1,234 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-augmented-lora-t0.0</th>
+      <td>3.31</td>
+      <td>9.92</td>
+      <td>33.33</td>
+      <td>3.08</td>
+      <td>50.00</td>
+      <td>57.74</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>4.0</td>
+      <td>58.57</td>
+      <td>2.02</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>56.67</td>
+      <td>17.65</td>
+      <td>39.30</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>38.30</td>
+      <td>35.42</td>
+      <td>23.54</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>66.67</td>
+      <td>5.00</td>
+      <td>22.07</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-personas-lora-t0.0</th>
+      <td>15.95</td>
+      <td>47.49</td>
+      <td>33.58</td>
+      <td>8.46</td>
+      <td>36.36</td>
+      <td>50.45</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>3.39</td>
+      <td>62.0</td>
+      <td>2.83</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>94.0</td>
+      <td>60.87</td>
+      <td>14.87</td>
+      <td>40.0</td>
+      <td>65.98</td>
+      <td>18.23</td>
+      <td>63.33</td>
+      <td>10.53</td>
+      <td>31.53</td>
+      <td>100.0</td>
+      <td>15.38</td>
+      <td>36.13</td>
+      <td>97.87</td>
+      <td>26.76</td>
+      <td>21.03</td>
+      <td>100.00</td>
+      <td>32.22</td>
+      <td>46.99</td>
+      <td>98.33</td>
+      <td>1.13</td>
+      <td>6.08</td>
+      <td>72.0</td>
+      <td>56.34</td>
+      <td>11.46</td>
+      <td>3.33</td>
+      <td>40.0</td>
+      <td>NaN</td>
+      <td>46.67</td>
+      <td>92.86</td>
+      <td>26.73</td>
+      <td>50.0</td>
+      <td>3.33</td>
+      <td>12.91</td>
+      <td>10.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>20.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+    </tr>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-wildchat-lora-t0.0</th>
+      <td>8.44</td>
+      <td>21.77</td>
+      <td>38.76</td>
+      <td>21.54</td>
+      <td>39.29</td>
+      <td>49.73</td>
+      <td>75.0</td>
+      <td>15.56</td>
+      <td>23.14</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>6.0</td>
+      <td>61.11</td>
+      <td>20.53</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>63.33</td>
+      <td>5.26</td>
+      <td>22.94</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>62.00</td>
+      <td>18.89</td>
+      <td>28.88</td>
+      <td>12.22</td>
+      <td>36.36</td>
+      <td>50.45</td>
+      <td>93.33</td>
+      <td>33.63</td>
+      <td>44.78</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>36.67</td>
+      <td>100.00</td>
+      <td>0.00</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_pref_personas_4*4_700.html
+++ b/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_pref_personas_4*4_700.html
@@ -1,0 +1,120 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-personas-lora-4*4-700-t0.0</th>
+      <td>14.39</td>
+      <td>34.79</td>
+      <td>41.35</td>
+      <td>25.38</td>
+      <td>21.21</td>
+      <td>41.51</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>84.0</td>
+      <td>62.0</td>
+      <td>17.31</td>
+      <td>33.33</td>
+      <td>59.48</td>
+      <td>21.71</td>
+      <td>100.0</td>
+      <td>23.33</td>
+      <td>43.02</td>
+      <td>100.0</td>
+      <td>33.33</td>
+      <td>47.2</td>
+      <td>40.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>100.0</td>
+      <td>36.67</td>
+      <td>48.46</td>
+      <td>60.0</td>
+      <td>19.91</td>
+      <td>36.04</td>
+      <td>2.0</td>
+      <td>60.0</td>
+      <td>NaN</td>
+      <td>6.67</td>
+      <td>38.89</td>
+      <td>7.86</td>
+      <td>40.0</td>
+      <td>100.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_wildchat.html
+++ b/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_IF_wildchat.html
@@ -1,0 +1,177 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-augmented-lora-t0.0</th>
+      <td>3.31</td>
+      <td>9.92</td>
+      <td>33.33</td>
+      <td>3.08</td>
+      <td>50.00</td>
+      <td>57.74</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>4.0</td>
+      <td>58.57</td>
+      <td>2.02</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>56.67</td>
+      <td>17.65</td>
+      <td>39.30</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>38.3</td>
+      <td>35.42</td>
+      <td>23.54</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>66.67</td>
+      <td>5.00</td>
+      <td>22.07</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-wildchat-lora-t0.0</th>
+      <td>8.44</td>
+      <td>21.77</td>
+      <td>38.76</td>
+      <td>21.54</td>
+      <td>39.29</td>
+      <td>49.73</td>
+      <td>75.0</td>
+      <td>15.56</td>
+      <td>23.14</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>6.0</td>
+      <td>61.11</td>
+      <td>20.53</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>63.33</td>
+      <td>5.26</td>
+      <td>22.94</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>62.0</td>
+      <td>18.89</td>
+      <td>28.88</td>
+      <td>12.22</td>
+      <td>36.36</td>
+      <td>50.45</td>
+      <td>93.33</td>
+      <td>33.63</td>
+      <td>44.78</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>36.67</td>
+      <td>100.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_pref_mixture.html
+++ b/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_pref_mixture.html
@@ -1,0 +1,126 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>matchit_ascii, % Played</th>
+      <th>matchit_ascii, Quality Score</th>
+      <th>matchit_ascii, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-mixture-t0.0</th>
+      <td>0.68</td>
+      <td>4.54</td>
+      <td>15.06</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>1.67</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>23.33</td>
+      <td>14.29</td>
+      <td>37.8</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>56.67</td>
+      <td>30.88</td>
+      <td>46.08</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_wildchat_on_policy_8b.html
+++ b/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_dpo_Tulu_wildchat_on_policy_8b.html
@@ -1,0 +1,126 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>matchit_ascii, % Played</th>
+      <th>matchit_ascii, Quality Score</th>
+      <th>matchit_ascii, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-wildchat-reused-on-policy-8b-t0.0</th>
+      <td>13.01</td>
+      <td>31.73</td>
+      <td>41.01</td>
+      <td>26.15</td>
+      <td>26.47</td>
+      <td>44.78</td>
+      <td>91.67</td>
+      <td>12.12</td>
+      <td>20.65</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>58.0</td>
+      <td>57.31</td>
+      <td>12.24</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>93.33</td>
+      <td>17.86</td>
+      <td>39.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>93.75</td>
+      <td>17.19</td>
+      <td>24.79</td>
+      <td>10.0</td>
+      <td>44.44</td>
+      <td>52.7</td>
+      <td>98.33</td>
+      <td>25.71</td>
+      <td>40.27</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>63.33</td>
+      <td>100.0</td>
+      <td>0.0</td>
+      <td>30.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>3.33</td>
+      <td>50.0</td>
+      <td>NaN</td>
+      <td>3.33</td>
+      <td>100.0</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>

--- a/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_sft_Tulu_IF_personas.html
+++ b/tulu/tulu-results/results_Llama_3.1_8b_it_4bit_sft_Tulu_IF_personas.html
@@ -1,0 +1,177 @@
+<table border="1" class="dataframe">
+  <thead>
+    <tr style="text-align: right;">
+      <th></th>
+      <th>-, clemscore</th>
+      <th>all, Average % Played</th>
+      <th>all, Average Quality Score</th>
+      <th>codenames, % Played</th>
+      <th>codenames, Quality Score</th>
+      <th>codenames, Quality Score (std)</th>
+      <th>guesswhat, % Played</th>
+      <th>guesswhat, Quality Score</th>
+      <th>guesswhat, Quality Score (std)</th>
+      <th>imagegame, % Played</th>
+      <th>imagegame, Quality Score</th>
+      <th>imagegame, Quality Score (std)</th>
+      <th>matchit, % Played</th>
+      <th>matchit, Quality Score</th>
+      <th>matchit, Quality Score (std)</th>
+      <th>mm_mapworld, % Played</th>
+      <th>mm_mapworld, Quality Score</th>
+      <th>mm_mapworld, Quality Score (std)</th>
+      <th>mm_mapworld_graphs, % Played</th>
+      <th>mm_mapworld_graphs, Quality Score</th>
+      <th>mm_mapworld_graphs, Quality Score (std)</th>
+      <th>mm_mapworld_specificroom, % Played</th>
+      <th>mm_mapworld_specificroom, Quality Score</th>
+      <th>mm_mapworld_specificroom, Quality Score (std)</th>
+      <th>multimodal_referencegame, % Played</th>
+      <th>multimodal_referencegame, Quality Score</th>
+      <th>multimodal_referencegame, Quality Score (std)</th>
+      <th>privateshared, % Played</th>
+      <th>privateshared, Quality Score</th>
+      <th>privateshared, Quality Score (std)</th>
+      <th>referencegame, % Played</th>
+      <th>referencegame, Quality Score</th>
+      <th>referencegame, Quality Score (std)</th>
+      <th>taboo, % Played</th>
+      <th>taboo, Quality Score</th>
+      <th>taboo, Quality Score (std)</th>
+      <th>textmapworld, % Played</th>
+      <th>textmapworld, Quality Score</th>
+      <th>textmapworld, Quality Score (std)</th>
+      <th>textmapworld_graphreasoning, % Played</th>
+      <th>textmapworld_graphreasoning, Quality Score</th>
+      <th>textmapworld_graphreasoning, Quality Score (std)</th>
+      <th>textmapworld_specificroom, % Played</th>
+      <th>textmapworld_specificroom, Quality Score</th>
+      <th>textmapworld_specificroom, Quality Score (std)</th>
+      <th>wordle, % Played</th>
+      <th>wordle, Quality Score</th>
+      <th>wordle, Quality Score (std)</th>
+      <th>wordle_withclue, % Played</th>
+      <th>wordle_withclue, Quality Score</th>
+      <th>wordle_withclue, Quality Score (std)</th>
+      <th>wordle_withcritic, % Played</th>
+      <th>wordle_withcritic, Quality Score</th>
+      <th>wordle_withcritic, Quality Score (std)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>llama3-8b-it-4bit-pref-personas-lora-4*4-700-t0.0</th>
+      <td>14.39</td>
+      <td>34.79</td>
+      <td>41.35</td>
+      <td>25.38</td>
+      <td>21.21</td>
+      <td>41.51</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>84.0</td>
+      <td>62.0</td>
+      <td>17.31</td>
+      <td>33.33</td>
+      <td>59.48</td>
+      <td>21.71</td>
+      <td>100.00</td>
+      <td>23.33</td>
+      <td>43.02</td>
+      <td>100.0</td>
+      <td>33.33</td>
+      <td>47.2</td>
+      <td>40.0</td>
+      <td>0.00</td>
+      <td>0.00</td>
+      <td>100.0</td>
+      <td>36.67</td>
+      <td>48.46</td>
+      <td>60.0</td>
+      <td>19.91</td>
+      <td>36.04</td>
+      <td>2.0</td>
+      <td>60.00</td>
+      <td>NaN</td>
+      <td>6.67</td>
+      <td>38.89</td>
+      <td>7.86</td>
+      <td>40.00</td>
+      <td>100.00</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+    <tr>
+      <th>llama3-8b-it-4bit-sft-personas-lora-t0.0</th>
+      <td>13.37</td>
+      <td>47.67</td>
+      <td>28.05</td>
+      <td>42.31</td>
+      <td>27.27</td>
+      <td>44.95</td>
+      <td>76.67</td>
+      <td>24.64</td>
+      <td>37.47</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>96.67</td>
+      <td>20.69</td>
+      <td>41.23</td>
+      <td>100.0</td>
+      <td>33.33</td>
+      <td>47.2</td>
+      <td>82.0</td>
+      <td>15.12</td>
+      <td>20.44</td>
+      <td>100.0</td>
+      <td>33.33</td>
+      <td>47.40</td>
+      <td>100.0</td>
+      <td>16.67</td>
+      <td>33.19</td>
+      <td>56.0</td>
+      <td>48.55</td>
+      <td>10.33</td>
+      <td>0.00</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>76.67</td>
+      <td>60.87</td>
+      <td>49.9</td>
+      <td>80.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+      <td>0.0</td>
+      <td>NaN</td>
+      <td>NaN</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
This branch explores whether enhancing a model’s general instruction-following abilities can improve performance in interactive game environments without using game-specific data. We apply mainly DPO tuning on Tulu 3 instruction-following datasets (https://huggingface.co/collections/allenai/tulu-3-datasets-673b8df14442393f7213f372) to test this hypothesis.

Key Results:
Base model: LLaMA 3.1 8B Instruct (4-bit, Unsloth tuned)
clemscore: 27.35 | statscore: 49.16

DPO-tuned on tulu-3-pref-personas-instruction-following
clemscore: 12.63 | statscore: 47.92